### PR TITLE
feat: ENTSO-E day-ahead prices (LT) CLI

### DIFF
--- a/nord-pool-data/.env.example
+++ b/nord-pool-data/.env.example
@@ -1,0 +1,3 @@
+# ENTSO-E Transparency Platform Web API token
+# Jei "Generate token" nematai, reikia, kad ENTSO-E įjungtų Web API prieigą tavo paskyrai.
+ENTSOE_TOKEN=PUT_YOUR_TOKEN_HERE

--- a/nord-pool-data/.gitignore
+++ b/nord-pool-data/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/nord-pool-data/README.md
+++ b/nord-pool-data/README.md
@@ -1,0 +1,23 @@
+# nord-pool-data
+
+Parsisiunčia **Day-Ahead (A44)** kainas Lietuvai (LT) iš **ENTSO-E** (REST API).
+- Endpoint: https://web-api.tp.entsoe.eu/api
+- LT zona (EIC): 10YLT-1001A0008Q
+- Reikalingas ENTSOE_TOKEN (`.env`)
+
+## Startas
+```bash
+cp .env.example .env  # įrašyk ENTSOE_TOKEN
+npm i
+npm run tomorrow      # rytojaus 24h (JSON)
+npm run next24h       # "rolling" 24h nuo dabar (JSON)
+```
+
+
+Pastabos
+
+Atsakymo laikas – UTC; konvertuojam į Europe/Vilnius (luxon).
+
+Vienetai iš ENTSO-E būna EUR/MWh – čia verčiam į EUR/kWh (÷1000).
+
+Palaikoma rezoliucija PT60M ir PT15M.

--- a/nord-pool-data/package.json
+++ b/nord-pool-data/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "nord-pool-data",
+  "version": "0.1.0",
+  "description": "Fetch 24h-ahead electricity prices for Lithuania (ENTSO-E A44 Day-Ahead).",
+  "type": "module",
+  "engines": { "node": ">=18.0.0" },
+  "scripts": {
+    "tomorrow": "node src/index.js tomorrow --zone LT --format json",
+    "next24h": "node src/index.js next24h --zone LT --format json",
+    "csv:tomorrow": "node src/index.js tomorrow --zone LT --format csv"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "fast-xml-parser": "^4.5.0",
+    "luxon": "^3.5.0",
+    "yargs": "^17.7.2"
+  }
+}

--- a/nord-pool-data/src/entsoe.js
+++ b/nord-pool-data/src/entsoe.js
@@ -1,0 +1,18 @@
+import { XMLParser } from "fast-xml-parser";
+
+export async function fetchEntsoeA44({ token, eic, periodStart, periodEnd }) {
+  const url = new URL("https://web-api.tp.entsoe.eu/api"); // oficialus TP Web API endpoint
+  url.searchParams.set("securityToken", token);
+  url.searchParams.set("documentType", "A44");     // Day-Ahead Prices
+  url.searchParams.set("in_Domain", eic);
+  url.searchParams.set("out_Domain", eic);
+  url.searchParams.set("periodStart", periodStart); // UTC, yyyyMMddHHmm
+  url.searchParams.set("periodEnd", periodEnd);     // UTC, yyyyMMddHHmm
+
+  const res = await fetch(url, { headers: { Accept: "application/xml" } });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`ENTSO-E error ${res.status}: ${text.slice(0,200)}...`);
+
+  const parser = new XMLParser({ ignoreAttributes: false }); // saugom atributus
+  return parser.parse(text);
+}

--- a/nord-pool-data/src/index.js
+++ b/nord-pool-data/src/index.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+import "dotenv/config";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+import { ZONES } from "./zones.js";
+import { fetchEntsoeA44 } from "./entsoe.js";
+import { normalizeA44ToSeries, sliceRolling24h } from "./normalize.js";
+import { tomorrowUtcBounds, rolling24hUtcWindow } from "./time.js";
+
+const argv = yargs(hideBin(process.argv))
+  .command("tomorrow", "Fetch tomorrow 00:00–24:00 (Europe/Vilnius)")
+  .command("next24h", "Fetch rolling 24h from now")
+  .option("zone",   { type: "string", default: "LT", describe: "Bidding zone (LT)" })
+  .option("format", { choices: ["json", "csv"], default: "json" })
+  .demandCommand(1)
+  .strict()
+  .help().argv;
+
+const mode = argv._[0];
+const zone = argv.zone.toUpperCase();
+const eic = ZONES[zone];
+if (!eic) { console.error(`Unknown zone ${zone}`); process.exit(1); }
+const token = process.env.ENTSOE_TOKEN;
+if (!token) { console.error("Missing ENTSOE_TOKEN in .env"); process.exit(1); }
+
+function toCSV(prices) {
+  const header = "startLocal,endLocal,value_EUR_per_kWh";
+  const rows = prices.map(p => `${p.startLocal},${p.endLocal},${p.value}`);
+  return [header, ...rows].join("\n");
+}
+
+if (mode === "tomorrow") {
+  const { periodStart, periodEnd } = tomorrowUtcBounds();
+  const js = await fetchEntsoeA44({ token, eic, periodStart, periodEnd });
+  const normalized = normalizeA44ToSeries(js, { eic });
+  if (!normalized) { console.error("No data returned (maybe not published yet)."); process.exit(2); }
+  if (argv.format === "csv") console.log(toCSV(normalized.prices));
+  else console.log(JSON.stringify(normalized, null, 2));
+  process.exit(0);
+}
+
+if (mode === "next24h") {
+  const { query1, query2, sliceFromUtc, sliceToUtc } = rolling24hUtcWindow();
+  const js1 = await fetchEntsoeA44({ token, eic, periodStart: query1.periodStart, periodEnd: query1.periodEnd });
+  const js2 = await fetchEntsoeA44({ token, eic, periodStart: query2.periodStart, periodEnd: query2.periodEnd });
+  const s1 = normalizeA44ToSeries(js1, { eic });
+  const s2 = normalizeA44ToSeries(js2, { eic });
+  const prices = sliceRolling24h(s1, s2, sliceFromUtc, sliceToUtc);
+  const payload = {
+    zone: "LT",
+    eic,
+    unit: "EUR/kWh",
+    resolution: (s1?.resolution || s2?.resolution || "PT60M"),
+    fromUTC: sliceFromUtc.toISO(),
+    toUTC: sliceToUtc.toISO(),
+    prices
+  };
+  if (argv.format === "csv") console.log(toCSV(payload.prices));
+  else console.log(JSON.stringify(payload, null, 2));
+  process.exit(0);
+}

--- a/nord-pool-data/src/normalize.js
+++ b/nord-pool-data/src/normalize.js
@@ -1,0 +1,48 @@
+import { DateTime } from "luxon";
+import { plusResolution } from "./time.js";
+
+export function normalizeA44ToSeries(jsDoc, { eic, tz = "Europe/Vilnius" }) {
+  const doc = jsDoc?.Publication_MarketDocument;
+  const series = Array.isArray(doc?.TimeSeries) ? doc.TimeSeries : (doc?.TimeSeries ? [doc.TimeSeries] : []);
+  if (!series.length) return null;
+
+  const currency = series[0]?.currency_Unit?.value || "EUR";
+  const out = [];
+  let resolution = "PT60M";
+  let fromUTC, toUTC;
+
+  for (const ts of series) {
+    const period = ts.Period;
+    const startISO = period?.timeInterval?.start;
+    const endISO = period?.timeInterval?.end;
+    const points = Array.isArray(period?.Point) ? period.Point : (period?.Point ? [period.Point] : []);
+    resolution = period?.resolution || resolution;
+
+    const startUtc = DateTime.fromISO(startISO, { zone: "utc" });
+    const endUtc = DateTime.fromISO(endISO, { zone: "utc" });
+    fromUTC = fromUTC ? DateTime.min(fromUTC, startUtc) : startUtc;
+    toUTC = toUTC ? DateTime.max(toUTC, endUtc) : endUtc;
+
+    for (const p of points) {
+      const pos = Number(p.position) - 1; // 1-based
+      const bucketStart = startUtc.plus({ minutes: resolution === "PT15M" ? pos * 15 : pos * 60 });
+      const bucketEnd = plusResolution(bucketStart, resolution);
+      const eurMWh = Number(p["price.amount"]);
+      out.push({
+        startUTC: bucketStart.toISO(),
+        endUTC: bucketEnd.toISO(),
+        startLocal: bucketStart.setZone(tz).toISO(),
+        endLocal: bucketEnd.setZone(tz).toISO(),
+        value: eurMWh / 1000 // EUR/kWh
+      });
+    }
+  }
+
+  out.sort((a, b) => a.startUTC.localeCompare(b.startUTC));
+  return { zone: "LT", eic, currency, resolution, unit: "EUR/kWh", fromUTC: fromUTC?.toISO(), toUTC: toUTC?.toISO(), prices: out };
+}
+
+export function sliceRolling24h(seriesDay1, seriesDay2, sliceFromUtc, sliceToUtc) {
+  const merged = [...(seriesDay1?.prices ?? []), ...(seriesDay2?.prices ?? [])];
+  return merged.filter(p => p.startUTC >= sliceFromUtc.toISO() && p.startUTC < sliceToUtc.toISO());
+}

--- a/nord-pool-data/src/time.js
+++ b/nord-pool-data/src/time.js
@@ -1,0 +1,43 @@
+import { DateTime, Duration } from "luxon";
+export const TZ = "Europe/Vilnius";
+
+export function dayBoundsUtc(localDateISO, tz = TZ) {
+  const startLocal = DateTime.fromISO(localDateISO, { zone: tz }).startOf("day");
+  const endLocal = startLocal.plus({ days: 1 });
+  return { startUTC: startLocal.toUTC(), endUTC: endLocal.toUTC() };
+}
+
+export function tomorrowUtcBounds(tz = TZ) {
+  const tomorrow = DateTime.now().setZone(tz).plus({ days: 1 }).startOf("day");
+  const { startUTC, endUTC } = dayBoundsUtc(tomorrow.toISODate(), tz);
+  const fmt = "yyyyLLddHHmm";
+  return {
+    periodStart: startUTC.toFormat(fmt),
+    periodEnd: endUTC.toFormat(fmt),
+    startUTC,
+    endUTC
+  };
+}
+
+export function rolling24hUtcWindow(tz = TZ) {
+  const nowLocal = DateTime.now().setZone(tz);
+  const fromUtc = nowLocal.toUTC();
+  const toUtc = fromUtc.plus({ hours: 24 });
+
+  const todayStart = nowLocal.startOf("day");
+  const tomorrowStart = todayStart.plus({ days: 1 });
+  const dayAfterStart = tomorrowStart.plus({ days: 1 });
+
+  const fmt = "yyyyLLddHHmm";
+  return {
+    query1: { periodStart: todayStart.toUTC().toFormat(fmt), periodEnd: tomorrowStart.toUTC().toFormat(fmt) },
+    query2: { periodStart: tomorrowStart.toUTC().toFormat(fmt), periodEnd: dayAfterStart.toUTC().toFormat(fmt) },
+    sliceFromUtc: fromUtc,
+    sliceToUtc: toUtc
+  };
+}
+
+export function plusResolution(dtUtc, resolution) {
+  const dur = resolution === "PT15M" ? Duration.fromObject({ minutes: 15 }) : Duration.fromObject({ hours: 1 });
+  return dtUtc.plus(dur);
+}

--- a/nord-pool-data/src/zones.js
+++ b/nord-pool-data/src/zones.js
@@ -1,0 +1,4 @@
+// ENTSO-E EIC zonų kodai. LT – Lietuvos bidding/scheduling area.
+export const ZONES = {
+  LT: "10YLT-1001A0008Q"
+};


### PR DESCRIPTION
## Summary
- add Node 18 ESM CLI to fetch ENTSO-E A44 day-ahead prices for Lithuania
- support `tomorrow` and `next24h` commands with JSON/CSV output
- document usage, environment setup and zone EIC

## Testing
- `npm i` *(fails: 403 Forbidden - GET https://registry.npmjs.org/dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c63dd4408325a23d93afc45cf96a